### PR TITLE
Fix error if no connection and sending command

### DIFF
--- a/eiscp.js
+++ b/eiscp.js
@@ -184,6 +184,7 @@ function command_to_iscp(command, args, zone) {
             return;
         }
     }
+    self.emit('debug', util.format('DEBUG (command_to_iscp) raw command "%s"', prefix + value));
 
     return prefix + value;
 }

--- a/eiscp.js
+++ b/eiscp.js
@@ -290,7 +290,7 @@ self.connect = function (options) {
     // If no host is configured - we connect to the first device to answer
     if (typeof config.host === 'undefined' || config.host === '') {
         self.discover(function (err, hosts) {
-            if (!err && hosts.length > 0) {
+            if (!err && hosts && hosts.length > 0) {
                 self.connect(hosts[0]);
             }
             return;
@@ -301,7 +301,7 @@ self.connect = function (options) {
     // If host is configured but no model is set - we send a discover directly to this receiver
     if (typeof config.model === 'undefined' || config.model === '') {
         self.discover({address: config.host}, function (err, hosts) {
-            if (!err && hosts.length > 0) {
+            if (!err && hosts && hosts.length > 0) {
                 self.connect(hosts[0]);
             }
             return;
@@ -321,7 +321,7 @@ self.connect = function (options) {
         });
     });
 
-    self.emit('debug', util.format("INFO (connecting) Connecting to %s:%s", config.host, config.port));
+    self.emit('debug', util.format("INFO (connecting) Connecting to %s:%s (model: %s)", config.host, config.port, config.model));
 
 	// Reconnect if we have previously connected
     if (typeof eiscp !== 'undefined') {
@@ -336,15 +336,15 @@ self.connect = function (options) {
 	on('connect', function () {
 
 		self.is_connected = true;
-		self.emit('debug', util.format("INFO (connected) Connected to %s:%s", config.host, config.port));
-		self.emit('connect');
+		self.emit('debug', util.format("INFO (connected) Connected to %s:%s (model: %s)", config.host, config.port, config.model));
+		self.emit('connect', config.host, config.port, config.model);
 	}).
 
 	on('close', function () {
 
 		self.is_connected = false;
 		self.emit('debug', util.format("INFO (disconnected) Disconnected from %s:%s", config.host, config.port));
-		self.emit('close');
+		self.emit('close', config.host, config.port);
 
 		if (config.reconnect) {
 
@@ -364,6 +364,9 @@ self.connect = function (options) {
 			result = iscp_to_command(iscp_message);
 
 		result.iscp_command = iscp_message;
+        result.host  = config.host;
+        result.port  = config.port;
+        result.model = config.model;
 
 		self.emit('debug', util.format("DEBUG (received_data) Received data from %s:%s - %j", config.host, config.port, result));
 		self.emit('data', result);
@@ -404,7 +407,7 @@ send_queue = async.queue(function (data, callback) {
     }
 
     self.emit('error', util.format("ERROR (send_not_connected) Not connected, can't send data: %j", data));
-    callback(err, null);
+    callback('Send command, while not connected', null);
 
 }, 1);
 


### PR DESCRIPTION
- Fix error if no connection exists and someone wants to send command
- Give by connect, data, close the information about device, because if discover used the ip,port and model are unknown.